### PR TITLE
Fixes mvn failure when path or any string param contains whitespaces

### DIFF
--- a/src/main/groovy/com/github/dkorotych/gradle/maven/cli/MavenCommandLineOptionsKeeper.groovy
+++ b/src/main/groovy/com/github/dkorotych/gradle/maven/cli/MavenCommandLineOptionsKeeper.groovy
@@ -147,6 +147,14 @@ class MavenCommandLineOptionsKeeper {
         this.supportedOptions.addAll(supportedOptions)
     }
 
+    String doubleQuoteIfNecessary(String value) {
+        String rc = value
+        if (rc =~ /\s/ && !rc.startsWith('"')) {
+            rc = "\"$rc\""
+        }
+        rc
+    }
+
     /**
      * Build command line options.
      *
@@ -155,13 +163,13 @@ class MavenCommandLineOptionsKeeper {
     List<String> toCommandLine() {
         List<String> value = []
         systemProperties.each {
-            value << "-D${it.key}=${it.value}"
+            value << "-D${it.key}=${doubleQuoteIfNecessary(it.value)}"
         }
         options.each {
             if (supportedOptions.isEmpty() || supportedOptions.contains(it.key)) {
                 value << it.key
                 if (StringUtils.isNotBlank(it.value)) {
-                    value << it.value
+                    value << doubleQuoteIfNecessary(it.value)
                 }
             }
         }

--- a/src/test/groovy/com/github/dkorotych/gradle/maven/cli/MavenCommandLineOptionsKeeperTest.groovy
+++ b/src/test/groovy/com/github/dkorotych/gradle/maven/cli/MavenCommandLineOptionsKeeperTest.groovy
@@ -143,11 +143,13 @@ class MavenCommandLineOptionsKeeperTest extends Specification {
         commandLine == keeper.toCommandLine()
 
         where:
-        option    | value         | commandLine
-        '--debug' | "    \n\n   " | []
-        '--debug' | "parameter"   | ['--debug', 'parameter']
-        '--debug' | null          | []
-        '--debug' | ''            | []
+        option    | value              | commandLine
+        '--debug' | "    \n\n   "      | []
+        '--debug' | "parameter"        | ['--debug', 'parameter']
+        '--debug' | "\"para meter\""   | ['--debug', '"para meter"']
+        '--debug' | "para meter"       | ['--debug', '"para meter"']
+        '--debug' | null               | []
+        '--debug' | ''                 | []
     }
 
     def "addOption with String value. Replace existing option"() {
@@ -178,9 +180,11 @@ class MavenCommandLineOptionsKeeperTest extends Specification {
         commandLine == keeper.toCommandLine()
 
         where:
-        option      | value              | commandLine
-        '--offline' | new File(userHome) | ['--offline', new File(userHome).absolutePath]
-        '--offline' | new File(tmp)      | ['--offline', new File(tmp).absolutePath]
+        option      | value                                      | commandLine
+        '--offline' | new File(userHome)                         | ['--offline', new File(userHome).absolutePath]
+        '--offline' | new File(tmp)                              | ['--offline', new File(tmp).absolutePath]
+        '--offline' | new File(userHome, 'path with whitespace') | ['--offline', "\"${new File(userHome, 'path with whitespace').absolutePath}\""]
+        '--offline' | new File(tmp, 'path with whitespace')      | ['--offline', "\"${new File(tmp, 'path with whitespace').absolutePath}\""]
     }
 
     def "addOption with File value. Replace existing option"() {


### PR DESCRIPTION
Hi,

I get an error when executing mvn with a custom settings.xml file. It's path contains whitespaces (Windows) which causes problems because the value should be double-quoted before passed as CLI parameter. This pull request fixes this.

Best regards,
Roland